### PR TITLE
removing the health check

### DIFF
--- a/templates/haproxy.conf
+++ b/templates/haproxy.conf
@@ -22,5 +22,5 @@ frontend caldera-https
 backend caldera_server
     balance leastconn
     cookie SERVERUSED insert indirect nocache
-    default-server check maxconn 20
+    default-server maxconn 20
     server caldera_main 127.0.0.1:8888 cookie caldera_main


### PR DESCRIPTION
HAProxy (for some reason) would connect to the caldera server and gave a 503 (despite the server being online).  Disabling the health check makes it work again