### PR TITLE
Add SSL plugin GUI, modify gitignore to include cert files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 .logs/*
 !.logs/.gitkeep
 core.db
+conf/haproxy.conf
+conf/certificate.pem

--- a/app/ssl_gui_api.py
+++ b/app/ssl_gui_api.py
@@ -1,0 +1,15 @@
+from aiohttp_jinja2 import template
+
+from app.utility.base_world import BaseWorld
+from app.service.auth_svc import for_all_public_methods, check_authorization
+
+
+@for_all_public_methods(check_authorization)
+class SslGuiApi(BaseWorld):
+
+    def __init__(self, services):
+        self.auth_svc = services.get('auth_svc')
+
+    @template('ssl.html')
+    async def splash(self, request):
+        return dict()

--- a/hook.py
+++ b/hook.py
@@ -4,9 +4,11 @@ import os.path
 from subprocess import Popen
 from ssl import get_server_certificate
 
+from plugins.ssl.app.ssl_gui_api import SslGuiApi
+
 name = 'SSL'
 description = 'Run an SSL proxy in front of the server'
-address = ''
+address = 'plugin/ssl/gui'
 
 
 def _read_default_cert():
@@ -29,10 +31,13 @@ async def _check_using_default_cert():
 
 
 async def enable(services):
+    app = services.get('app_svc').application
     haproxy_conf = 'plugins/ssl/templates/haproxy.conf'
     user_conf = 'plugins/ssl/conf/haproxy.conf'
     if os.path.isfile(user_conf):
         haproxy_conf = user_conf
     Popen(['haproxy', '-q', '-f', haproxy_conf])
+    ssl_gui_api = SslGuiApi(services=services)
+    app.router.add_route('GET', '/plugin/ssl/gui', ssl_gui_api.splash)
     loop = asyncio.get_event_loop()
     loop.create_task(_check_using_default_cert())

--- a/templates/ssl.html
+++ b/templates/ssl.html
@@ -4,8 +4,8 @@
          <div class="column" style="flex:40%;padding:15px;text-align: left">
             <h1 style="font-size:70px;margin-top:-20px;">SSL</h1>
             <h2 style="margin-top:-55px">add HTTPS to CALDERA</h2>
-            <p>When this plugin has been loaded, CALDERA will start the HAProxy service on the machine and serve CALDERA on all interfaces on port 8443, in addition to the normal http://[YOUR_IP]:8888 (based on the value of the host value in the CALDERA settings).</p>
-            <p>Follow the <a style="text-decoration: underline;" href="https://localhost:8443/docs/Plugin-library.html#ssl" target="_blank">Setup Instructions</a> after enabling the plugin.</p>
+            <p>This plugin creates an HTTPS interface for CALDERA, allowing users and agents to securely communicate with the server.</p>
+            <p>See the <a style="text-decoration: underline;" href="/docs/Plugin-library.html#ssl" target="_blank">plugin documentation</a> for setup instructions.</p>
         </div>
     </div>
 </div>

--- a/templates/ssl.html
+++ b/templates/ssl.html
@@ -1,0 +1,16 @@
+<div id="ssl-section" class="section-profile">
+    <div class="row">
+         <div class="topleft duk-icon"><img onclick="removeSection('ssl-section')" src="/gui/img/x.png"></div>
+         <div class="column" style="flex:40%;padding:15px;text-align: left">
+            <h1 style="font-size:70px;margin-top:-20px;">SSL</h1>
+            <h2 style="margin-top:-55px">add HTTPS to CALDERA</h2>
+            <h5>When this plugin has been loaded, CALDERA will start the HAProxy service on the machine and serve CALDERA on all interfaces on port 8443, in addition to the normal http://[YOUR_IP]:8888 (based on the value of the host value in the CALDERA settings).</h5>
+            <p>Follow the <a style="text-decoration: underline;" href="https://localhost:8443/docs/Plugin-library.html#ssl" target="_blank">Setup Instructions</a> after enabling the plugin.</p>
+        </div>
+    </div>
+</div>
+<script>
+    $(document).ready(function () {
+        stream('Ensure you redeploy your agents after enabling SSL for them to run on the new HTTPS service.');
+    });
+</script>

--- a/templates/ssl.html
+++ b/templates/ssl.html
@@ -4,7 +4,7 @@
          <div class="column" style="flex:40%;padding:15px;text-align: left">
             <h1 style="font-size:70px;margin-top:-20px;">SSL</h1>
             <h2 style="margin-top:-55px">add HTTPS to CALDERA</h2>
-            <h5>When this plugin has been loaded, CALDERA will start the HAProxy service on the machine and serve CALDERA on all interfaces on port 8443, in addition to the normal http://[YOUR_IP]:8888 (based on the value of the host value in the CALDERA settings).</h5>
+            <p>When this plugin has been loaded, CALDERA will start the HAProxy service on the machine and serve CALDERA on all interfaces on port 8443, in addition to the normal http://[YOUR_IP]:8888 (based on the value of the host value in the CALDERA settings).</p>
             <p>Follow the <a style="text-decoration: underline;" href="https://localhost:8443/docs/Plugin-library.html#ssl" target="_blank">Setup Instructions</a> after enabling the plugin.</p>
         </div>
     </div>


### PR DESCRIPTION
## Description

Add a basic UI to the SSL plugin, very similar to that of Sandcat.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Clicking "SSL" under Plugins makes a new window appear with more info on the plugin, and clicking the X makes it disappear.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (n/a)
- [ ] I have added tests that prove my fix is effective or that my feature works (n/a)
