### PR TITLE
Update SSL plugin to new UI

### DIFF
--- a/templates/ssl.html
+++ b/templates/ssl.html
@@ -1,16 +1,38 @@
-<div id="ssl-section" class="section-profile">
-    <div class="row">
-         <div class="topleft duk-icon"><img onclick="removeSection('ssl-section')" src="/gui/img/x.png"></div>
-         <div class="column" style="flex:40%;padding:15px;text-align: left">
-            <h1 style="font-size:70px;margin-top:-20px;">SSL</h1>
-            <h2 style="margin-top:-55px">add HTTPS to CALDERA</h2>
-            <p>This plugin creates an HTTPS interface for CALDERA, allowing users and agents to securely communicate with the server.</p>
-            <p>See the <a style="text-decoration: underline;" href="/docs/Plugin-library.html#ssl" target="_blank">plugin documentation</a> for setup instructions.</p>
-        </div>
+<div x-data="alpineSsl">
+    <div>
+        <h2>SSL</h2>
+        <p>
+            Add HTTPS to CALDERA
+        </p>
+    </div>
+    <hr>
+    <div id="ssl-content" class="is-flex is-flex-direction-column is-align-items-center is-justify-content-center">
+        <p class="block" x-bind:class="{ 'has-text-success': isHttps, 'has-text-danger': !isHttps }">
+            You are 
+            <span x-show="!isHttps">not</span>
+            using CALDERA over HTTPS
+        </p>
+
+        <p class="block">This plugin creates an HTTPS interface for CALDERA, allowing users and agents to securely communicate with the server.</p>
+        
+        <a class="button is-primary is-small" href="/docs/Plugin-library.html#ssl" target="_blank">
+            <span>Setup Instructions</span>
+            <span class="icon"><em class="fas fa-angle-right"></em></span>
+        </a>
     </div>
 </div>
+
 <script>
-    $(document).ready(function () {
-        stream('Ensure you redeploy your agents after enabling SSL for them to run on the new HTTPS service.');
-    });
+function alpineSsl() {
+    return {
+        isHttps: location.protocol === 'https:'
+    }
+}
 </script>
+
+<style scoped>
+    #ssl-content {
+        height: 50%;
+        width: 100%;
+    }
+</style>


### PR DESCRIPTION
## Description

Updates SSL UI to match the rest of the platform. It also adds some text to tell the user whether or not they are using CALDERA over HTTPS or not.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested in Chrome, FF, and Safari and all looks good.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
