### PR TITLE
Replace deprecated logging function

### DIFF
--- a/hook.py
+++ b/hook.py
@@ -26,7 +26,7 @@ async def _check_using_default_cert():
     server_cert = get_server_certificate(('127.0.0.1', 8443))
     default_cert = _read_default_cert()
     if server_cert == default_cert:
-        logging.warn('Insecure SSL private key and certificate in use. Consider generating and using your own '
+        logging.warning('Insecure SSL private key and certificate in use. Consider generating and using your own '
                      'to improve security. Please see documentation.')
 
 


### PR DESCRIPTION
## Description

Python's `logging.warn` is deprecated and should be replaced by the functionally equivalent `logging.warning`. As mentioned in [the documentation of the logging module](https://docs.python.org/3/library/logging.html#logging.Logger.warning)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Functionally equivalent.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
